### PR TITLE
Add script to zip files for Chrome

### DIFF
--- a/manifests/manifest.json
+++ b/manifests/manifest.json
@@ -2,10 +2,9 @@
   "description": "Serato Firewall Header",
   "manifest_version": 2,
   "name": "serato-firewall-header",
-  "version": "1.7.0",
   "homepage_url": "https://github.com/harrietrc/SimpleModifyHeaders",
   "icons": {
-    "48": "icons/stop.png"
+    "40": "icons/stop.png"
   },
   "permissions": [
     "activeTab",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serato-firewall-header",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@babel/preset-env": "^7.7.0",
@@ -17,6 +17,7 @@
     "sign:firefox": "webpack --env.browser=firefox && web-ext sign --api-key $WEB_EXT_API_KEY --api-secret $WEB_EXT_API_SECRET --channel unlisted --ignore-files 'tests/*' 'tests' 'serato-firewall-header.js' 'web-ext-artifacts' 'web-ext-artifacts/*' 'package.json' 'node_modules' 'node_modules/*' 'manifests' 'manifests/*' 'lib' 'lib/*'",
     "lint": "web-ext lint",
     "test": "open ./tests/SpecRunner.html # Note: these scripts won't return a non-zero error code on test failure",
-    "test:windows": "start ./tests/SpecRunner.html"
+    "test:windows": "start ./tests/SpecRunner.html",
+    "package:chrome": "webpack --env.browser=chrome && web-ext build --ignore-files 'tests/*' 'tests' 'serato-firewall-header.js' 'web-ext-artifacts' 'web-ext-artifacts/*' 'package.json' 'node_modules' 'node_modules/*' 'manifests' 'manifests/*' 'lib' 'lib/*'"
   }
 }


### PR DESCRIPTION
- Add `package:chrome` npm script to zip extension (without node_modules et al.) for Chrome